### PR TITLE
Add support for custom prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "termion",
  "tokio",
 ]
 
@@ -140,6 +141,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -251,7 +258,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -773,11 +780,22 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -895,6 +913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,7 +939,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -977,7 +1001,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.11",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1082,12 +1106,27 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -1096,7 +1135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
- "libredox",
+ "libredox 0.1.3",
  "thiserror",
 ]
 
@@ -1199,7 +1238,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1278,7 +1317,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1470,7 +1509,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1496,6 +1535,18 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termion"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
+dependencies = [
+ "libc",
+ "libredox 0.0.2",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]
@@ -2084,7 +2135,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0" # エラーハンドリングを簡単にする
 clap = { version = "4.5", features = ["derive"] } # コマンドライン引数のパース
 dirs = "5.0" # ホームディレクトリなどの特殊なディレクトリを取得する
 promptuity = "0.0.5"
+termion = "2.0.1"
 
 [dev-dependencies]
 mockito = "1.2.0" # HTTP APIのモック

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ aic config --api
 # Set language for commit messages (interactive)
 aic config --language
 
+# Set custom prompt for commit messages (interactive)
+aic config --prompt
+
 # Show current configuration
 aic config --show
 ```
@@ -102,6 +105,29 @@ Available language options:
 - JA: Japanese (default)
 - EN: English
 - CN: Chinese
+
+### Custom Prompts
+
+You can set your own custom system prompt to control how AI generates commit messages:
+
+```
+aic config --prompt
+```
+
+This will open a simple vim-like editor where you can write and edit your custom prompt with multi-line support. Key controls:
+
+- Use arrow keys to navigate
+- Type to insert text
+- Press `Ctrl+S` to save changes
+- Press `Esc` to exit without saving
+
+This allows you to specify custom instructions for the AI model. For example:
+
+- Enforce specific commit message conventions
+- Adjust the style or format of commit messages
+- Add project-specific context or requirements
+
+When a custom prompt is set, it will be used instead of the default system prompt for the selected language. To return to using the default prompt, set an empty custom prompt.
 
 ### Generating Commit Messages
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,0 +1,238 @@
+use anyhow::Result;
+use std::io::{Write, stdin, stdout};
+use termion::event::Key;
+use termion::input::TermRead;
+use termion::raw::IntoRawMode;
+use termion::{clear, cursor};
+
+pub struct Editor {
+    content: Vec<String>,
+    cursor_x: usize,
+    cursor_y: usize,
+    message: String,
+}
+
+impl Editor {
+    pub fn _new() -> Self {
+        Self {
+            content: vec![String::new()],
+            cursor_x: 0,
+            cursor_y: 0,
+            message: String::from("-- INSERT MODE -- (Press Esc to exit, Ctrl+S to save)"),
+        }
+    }
+
+    // テスト用ゲッターメソッド
+    #[cfg(test)]
+    pub fn get_content(&self) -> &Vec<String> {
+        &self.content
+    }
+
+    #[cfg(test)]
+    pub fn get_cursor_position(&self) -> (usize, usize) {
+        (self.cursor_x, self.cursor_y)
+    }
+
+    #[cfg(test)]
+    pub fn get_message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn with_content(text: &str) -> Self {
+        let content = if text.is_empty() {
+            vec![String::new()]
+        } else {
+            text.lines()
+                .map(|line| line.to_string())
+                .collect::<Vec<String>>()
+        };
+
+        Self {
+            content,
+            cursor_x: 0,
+            cursor_y: 0,
+            message: String::from("-- INSERT MODE -- (Press Esc to exit, Ctrl+S to save)"),
+        }
+    }
+
+    pub fn run(&mut self) -> Result<String> {
+        let stdin = stdin();
+        let mut stdout = stdout().into_raw_mode()?;
+
+        // 画面をクリアして初期表示
+        write!(stdout, "{}{}", clear::All, cursor::Goto(1, 1))?;
+        self.draw(&mut stdout)?;
+        stdout.flush()?;
+
+        // キー入力処理
+        for c in stdin.keys() {
+            match c? {
+                // 終了
+                Key::Esc => {
+                    // 画面をクリアして終了メッセージを表示
+                    write!(stdout, "{}{}", clear::All, cursor::Goto(1, 1))?;
+                    write!(stdout, "Editor closed.\n\n")?;
+                    stdout.flush()?;
+                    break;
+                }
+                // 保存して終了
+                Key::Ctrl('s') => {
+                    self.message = String::from("Changes saved. Press Esc to exit.");
+                    self.draw(&mut stdout)?;
+                    stdout.flush()?;
+
+                    // 保存内容を返す準備
+                    let mut content = String::new();
+                    for line in &self.content {
+                        content.push_str(line);
+                        content.push('\n');
+                    }
+
+                    // 画面をクリアして保存メッセージを表示
+                    write!(stdout, "{}{}", clear::All, cursor::Goto(1, 1))?;
+                    write!(stdout, "Changes saved. Editor closed.\n\n")?;
+                    stdout.flush()?;
+
+                    return Ok(content);
+                }
+                // カーソル移動
+                Key::Left => {
+                    if self.cursor_x > 0 {
+                        self.cursor_x -= 1;
+                    }
+                }
+                Key::Right => {
+                    if self.cursor_x < self.content[self.cursor_y].len() {
+                        self.cursor_x += 1;
+                    }
+                }
+                Key::Up => {
+                    if self.cursor_y > 0 {
+                        self.cursor_y -= 1;
+                        self.cursor_x =
+                            std::cmp::min(self.cursor_x, self.content[self.cursor_y].len());
+                    }
+                }
+                Key::Down => {
+                    if self.cursor_y < self.content.len() - 1 {
+                        self.cursor_y += 1;
+                        self.cursor_x =
+                            std::cmp::min(self.cursor_x, self.content[self.cursor_y].len());
+                    }
+                }
+                // 改行
+                Key::Char('\n') => {
+                    let current_line = &self.content[self.cursor_y];
+                    let new_line = if self.cursor_x < current_line.len() {
+                        current_line[self.cursor_x..].to_string()
+                    } else {
+                        String::new()
+                    };
+
+                    if self.cursor_x < current_line.len() {
+                        self.content[self.cursor_y] = current_line[..self.cursor_x].to_string();
+                    }
+
+                    self.content.insert(self.cursor_y + 1, new_line);
+                    self.cursor_y += 1;
+                    self.cursor_x = 0;
+                }
+                // バックスペース
+                Key::Backspace => {
+                    if self.cursor_x > 0 {
+                        let line = &mut self.content[self.cursor_y];
+                        let mut chars: Vec<char> = line.chars().collect();
+                        chars.remove(self.cursor_x - 1);
+                        *line = chars.into_iter().collect();
+                        self.cursor_x -= 1;
+                    } else if self.cursor_y > 0 {
+                        // 行の先頭で行を削除
+                        let line = self.content.remove(self.cursor_y);
+                        self.cursor_y -= 1;
+                        self.cursor_x = self.content[self.cursor_y].len();
+                        self.content[self.cursor_y].push_str(&line);
+                    }
+                }
+                // 通常文字入力
+                Key::Char(c) => {
+                    if self.cursor_y >= self.content.len() {
+                        self.content.push(String::new());
+                    }
+
+                    let line = &mut self.content[self.cursor_y];
+                    let mut chars: Vec<char> = line.chars().collect();
+                    chars.insert(self.cursor_x, c);
+                    *line = chars.into_iter().collect();
+                    self.cursor_x += 1;
+                }
+                _ => {}
+            }
+
+            // 画面を更新
+            write!(stdout, "{}", clear::All)?;
+            self.draw(&mut stdout)?;
+            stdout.flush()?;
+        }
+
+        // 編集内容を文字列として返す
+        let mut content = String::new();
+        for line in &self.content {
+            content.push_str(line);
+            content.push('\n');
+        }
+
+        // 画面をクリアして終了メッセージを表示
+        write!(stdout, "{}{}", clear::All, cursor::Goto(1, 1))?;
+        write!(stdout, "Editor closed. No changes saved.\n\n")?;
+        stdout.flush()?;
+
+        Ok(content)
+    }
+
+    fn draw<W: Write>(&self, stdout: &mut W) -> Result<()> {
+        // ファイル内容を表示
+        for (i, line) in self.content.iter().enumerate() {
+            write!(stdout, "{}{}", cursor::Goto(1, (i + 1) as u16), line)?;
+        }
+
+        // ステータスメッセージを表示
+        write!(
+            stdout,
+            "{}{}",
+            cursor::Goto(1, (self.content.len() + 2) as u16),
+            self.message
+        )?;
+
+        // カーソル位置を設定
+        write!(
+            stdout,
+            "{}",
+            cursor::Goto((self.cursor_x + 1) as u16, (self.cursor_y + 1) as u16)
+        )?;
+
+        Ok(())
+    }
+
+    // テスト用にテキスト処理関数を公開
+    #[cfg(test)]
+    pub fn process_text_for_test(&mut self, text: &str) -> String {
+        // 改行をシンプルに処理するテスト用関数
+        let mut lines = vec![];
+        for line in text.lines() {
+            lines.push(line.to_string());
+        }
+        self.content = lines;
+        
+        // テキストに行を追加
+        self.content.push("Test added line".to_string());
+        
+        // 内容を文字列として返す
+        let mut result = String::new();
+        for line in &self.content {
+            result.push_str(line);
+            result.push('\n');
+        }
+        
+        result
+    }
+}


### PR DESCRIPTION
- Introduce a new `custom_prompt` field in the `Config` struct to store user-defined custom prompts
- Implement a simple vim-like editor for inputting and editing custom prompts with multi-line support
- Update the commit message generation logic to use the custom prompt if set, otherwise fallback to the default prompt for the selected language
- Add new `--prompt` flag to the `config` subcommand for setting custom prompts interactively
- Update documentation with details on using custom prompts

Custom prompts allow users to specify their own instructions for the AI model when generating commit messages. This enables enforcing specific conventions, adjusting styles, or including additional context.